### PR TITLE
Asymmetric gravity for snappier jump feel

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,11 @@
         </div>
     </div>
     <script>
-        window.addEventListener('load', function () {
-            document.getElementById('start-button').addEventListener('click', function () {
+        window.addEventListener('load', () => {
+            document.getElementById('start-button').addEventListener('click', () => {
                 document.getElementById('startScreen').style.display = 'none';
                 document.getElementById('instructions').style.display = 'block';
-                setTimeout(function () {
+                setTimeout(() => {
                     document.getElementById('instructions').style.display = 'none';
                 }, 2000);
 

--- a/src/js/constants/index.js
+++ b/src/js/constants/index.js
@@ -13,6 +13,8 @@
 
 export const GRAVITY = 0.5;
 export const JUMP_FORCE = -15;
+export const FALL_MULTIPLIER = 2.5;
+export const LOW_JUMP_MULTIPLIER = 2.0;
 export const MOVEMENT_SPEED = 5;
 export const FRICTION = 0.8;
 export const MAX_HEALTH = 100;

--- a/src/js/logic/classes/player.js
+++ b/src/js/logic/classes/player.js
@@ -1,8 +1,10 @@
 import { assets } from "../../assets";
 import {
+  FALL_MULTIPLIER,
   FRICTION,
   GRAVITY,
   JUMP_FORCE,
+  LOW_JUMP_MULTIPLIER,
   MAX_HEALTH,
   MOVEMENT_SPEED,
 } from "../../constants";
@@ -71,7 +73,14 @@ export default class Player {
     }
     this.lastKeyT = keys["KeyT"];
 
-    this.velocityY += GRAVITY;
+    const jumpPressed = keys["ArrowUp"] || keys["KeyW"] || keys["Space"];
+    if (this.velocityY > 0) {
+      this.velocityY += GRAVITY * FALL_MULTIPLIER;
+    } else if (this.velocityY < 0 && !jumpPressed) {
+      this.velocityY += GRAVITY * LOW_JUMP_MULTIPLIER;
+    } else {
+      this.velocityY += GRAVITY;
+    }
 
     if (this.velocityY > 15) {
       this.velocityY = 15;

--- a/tests/player.test.js
+++ b/tests/player.test.js
@@ -1,5 +1,5 @@
 import Player from "../src/js/logic/classes/player.js";
-import { GRAVITY, MAX_HEALTH } from "../src/js/constants";
+import { GRAVITY, FALL_MULTIPLIER, LOW_JUMP_MULTIPLIER, MAX_HEALTH } from "../src/js/constants";
 
 jest.mock("../src/js/logic/classes/sound.js", () => ({
   playSound: jest.fn(),
@@ -401,11 +401,10 @@ describe("Player Damage and Movement Methods", () => {
   });
 
   test("should apply gravity and cap falling speed", () => {
+    // Falling (velocityY > 0): FALL_MULTIPLIER applied
     player.velocityY = 10;
     player.update({}, 800, 600);
-
-    // Gravity should increase velocityY
-    expect(player.velocityY).toBe(10 + GRAVITY);
+    expect(player.velocityY).toBe(10 + GRAVITY * FALL_MULTIPLIER);
 
     // Set velocityY to the just below cap
     player.velocityY = 14.9;
@@ -423,7 +422,8 @@ describe("Player Damage and Movement Methods", () => {
     player.update({}, 800, 600);
 
     expect(player.x).toBe(initialX + 4);
-    expect(player.y).toBe(97.5);
+    // velocityY=-3, no jump held → LOW_JUMP_MULTIPLIER applies: y = 100 + (-3 + GRAVITY * LOW_JUMP_MULTIPLIER)
+    expect(player.y).toBe(100 + (-3 + GRAVITY * LOW_JUMP_MULTIPLIER));
 
   });
 


### PR DESCRIPTION
## Summary

Replaces the flat gravity constant with asymmetric gravity — the technique used in virtually every modern platformer to avoid floaty jumps.

**Before:** `GRAVITY = 0.5` applied uniformly every frame → ~1 second total air time, floaty descent.

**After:** three gravity states:
| State | Gravity applied |
|---|---|
| Rising, jump held | `GRAVITY × 1` (0.5) — normal, smooth ascent |
| Rising, jump released | `GRAVITY × LOW_JUMP_MULTIPLIER` (1.0) — cuts jump short for variable height |
| Falling | `GRAVITY × FALL_MULTIPLIER` (1.25) — fast, satisfying drop |

Same jump height on a full press, but the fall is 2.5× faster so the arc feels punchy. Tapping jump gives a noticeably shorter hop.

Two new tuning constants in `src/js/constants/index.js`:
- `FALL_MULTIPLIER = 2.5`
- `LOW_JUMP_MULTIPLIER = 2.0`

## Test plan

- [ ] Full jump (hold jump key) — arc should feel snappy, not floaty
- [ ] Tap jump — short hop noticeably smaller than full jump
- [ ] Stomp enemies — bounce still works correctly
- [ ] `npm test` — 118 tests pass